### PR TITLE
Update details, fix color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# bitbar-rescuetime-plugin
-Display your RescueTime productivity pulse (and more!) on your Mac menu bar. Based on [BitBar](https://github.com/matryer/bitbar).
+# xbar-rescuetime-plugin
+Display your RescueTime productivity pulse (and more!) on your Mac menu bar. Based on [xbar](https://github.com/matryer/xbar).
 
 ![RescueTime Plugin Screenshot](https://raw.githubusercontent.com/jckyeh/bitbar-rescuetime-plugin/assets/rescuetimePlugin-dropdown.png)
 
@@ -8,10 +8,10 @@ This plugin displays your “productivity score,” and how much time is “very
 Read more about the background of this project nad how it is impacting my productivity [here](https://jackyeh.me/project/rescuetime-mac-menu-bar-app/).
 
 ## Installation
-1. Download the latest version of [BitBar](https://github.com/matryer/bitbar/releases). 
+1. Download the latest version of [xbar](https://github.com/matryer/xbar/releases). 
 2. Copy it to your Applications folder and run it. 
 3. Follow the prompts to create and select a plugins folder.
 4. Download this plugin and move to your plugins directory.
 5. Create a new API key from your RescueTime account [here](https://www.rescuetime.com/anapi/manage).
 6. Store the key in `~/Library/RescueTime.com/api.key`.
-7. Hit `Refresh` from one of the BitBar menus.
+7. Hit `Refresh` from one of the xbar menus.

--- a/rescuetime.5m.js
+++ b/rescuetime.5m.js
@@ -112,7 +112,7 @@ request(endpoint_today).then((json) => {
   //console.log(`🎯${score}  (${hoursToString(vpHours)} of ${hoursToString(today_hours)}) | color=${getColorFromScore(score)}`);
   console.log(`${score}%  | color=${getColorFromScore(score)}`);
   console.log(`---`);
-  console.log(`${getTickOrCross(score)} Today: ${score} | href=https://www.rescuetime.com/dashboard color=black`);
+  console.log(`${getTickOrCross(score)} Today: ${score}% | href=https://www.rescuetime.com/dashboard color=black`);
   console.log(`${hoursToString(vpHours)} of ${hoursToString(today_hours)} (${Math.round(vpHours/today_hours*100)}%)`)
   console.log(`---`);
 }).catch((error) => {
@@ -126,7 +126,7 @@ request(endpoint_week).then((json) => {
   const data_thisWeek = json.slice(0, 6); // Slice works differently in node vs. with BitBar. In BitBar, slice removes end index.
 
   data_thisWeek.forEach((data_day) => {
-    console.log(`${getTickOrCross(data_day.very_productive_hours)} ${getDayOfWeek(data_day.date)}: ${data_day.productivity_pulse} | href=${URL_DASH_DAY}${data_day.date} color=black`)
+    console.log(`${getTickOrCross(data_day.very_productive_hours)} ${getDayOfWeek(data_day.date)}: ${data_day.productivity_pulse}% | href=${URL_DASH_DAY}${data_day.date} color=black`)
     console.log(`${hoursToString(data_day.very_productive_hours)} of ${hoursToString(data_day.total_hours)} (${data_day.very_productive_percentage}%)`)
     console.log(`---`)
   })

--- a/rescuetime.5m.js
+++ b/rescuetime.5m.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env /usr/local/bin/node
 
-// <bitbar.title>People In Space</bitbar.title>
+// <bitbar.title>RescueTime Productivity Stats</bitbar.title>
 // <bitbar.version>v1.1</bitbar.version>
 // <bitbar.author>Mullwar</bitbar.author>
 // <bitbar.author.github>mullwar</bitbar.author.github>
-// <bitbar.desc>How many people are in Space right now?</bitbar.desc>
-// <bitbar.image>http://i.imgur.com/i9biB3R.png</bitbar.image>
+// <bitbar.desc>Show RescueTime Productivity in menubar</bitbar.desc>
+// <bitbar.image>https://i.imgur.com/7ShrdlB.png</bitbar.image>
 // <bitbar.dependencies>node</bitbar.dependencies>
 // <bitbar.abouturl>https://github.com/mullwar/bitbar-plugins</bitbar.abouturl>
 
@@ -16,7 +16,6 @@
 
 const https = require('https');
 const fs = require('fs');
-
 
 // Rescue time API key. Need to manually create an api.key file
 const PATH = `${process.env.HOME}/Library/RescueTime.com/api.key`;
@@ -57,7 +56,7 @@ function getDayOfWeek(date) {
 }
 
 function getColorFromScore(score) {
-  return (score >= 69 ? 'black' : 'red');
+  return (score >= 69 ? 'lightgreen' : 'red');
 }
 
 function getTickOrCross(score) {
@@ -109,7 +108,8 @@ request(endpoint_today).then((json) => {
     score = Math.floor((1*vpHours + .75*pHours + .5*nHours + .25*dHours + 0*vdHours)/today_hours*100);
   }
 
-  console.log(`🎯${score}  (${hoursToString(vpHours)} of ${hoursToString(today_hours)}) | color=${getColorFromScore(score)}`);
+  //console.log(`🎯${score}  (${hoursToString(vpHours)} of ${hoursToString(today_hours)}) | color=${getColorFromScore(score)}`);
+  console.log(`${score}%  | color=${getColorFromScore(score)}`);
   console.log(`---`);
   console.log(`${getTickOrCross(score)} Today: ${score} | href=https://www.rescuetime.com/dashboard color=black`);
   console.log(`${hoursToString(vpHours)} of ${hoursToString(today_hours)} (${Math.round(vpHours/today_hours*100)}%)`)

--- a/rescuetime.5m.js
+++ b/rescuetime.5m.js
@@ -112,7 +112,7 @@ request(endpoint_today).then((json) => {
   //console.log(`🎯${score}  (${hoursToString(vpHours)} of ${hoursToString(today_hours)}) | color=${getColorFromScore(score)}`);
   console.log(`${score}%  | color=${getColorFromScore(score)}`);
   console.log(`---`);
-  console.log(`${getTickOrCross(score)} Today: ${score}% | href=https://www.rescuetime.com/dashboard color=black`);
+  console.log(`${getTickOrCross(vpHours)} Today: ${score}% | href=https://www.rescuetime.com/dashboard color=black`);
   console.log(`${hoursToString(vpHours)} of ${hoursToString(today_hours)} (${Math.round(vpHours/today_hours*100)}%)`)
   console.log(`---`);
 }).catch((error) => {
@@ -133,4 +133,3 @@ request(endpoint_week).then((json) => {
 }).catch((error) => {
   console.log(error)
 })
-

--- a/rescuetime.5m.js
+++ b/rescuetime.5m.js
@@ -27,7 +27,8 @@ const ENDPOINT_ACTIVITIES = 'https://www.rescuetime.com/anapi/data.json';
 const URL_DASH_DAY = 'https://www.rescuetime.com/dashboard/for/the/day/of/';
 
 let endpoint_week = `${ENDPOINT_FEED}?key=${API_KEY}`;
-let endpoint_today = `${ENDPOINT_ACTIVITIES}?key=${API_KEY}&perspective=interval&restrict_kind=productivity`;
+// Note &restrict_schedule_id=6839529, it restricts to 'work' schedule: https://www.rescuetime.com/dashboard?schedule_id=6839529
+let endpoint_today = `${ENDPOINT_ACTIVITIES}?key=${API_KEY}&perspective=interval&restrict_kind=productivity&restrict_schedule_id=6839529`;
 
 
 function request(endpoint) {
@@ -51,7 +52,7 @@ function request(endpoint) {
 
 function getDayOfWeek(date) {
   const dateObj = new Date(date);
-  const days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday', 'Sunday'];
+  const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   return days[dateObj.getDay()];
 }
 
@@ -60,7 +61,7 @@ function getColorFromScore(score) {
 }
 
 function getTickOrCross(score) {
-  return (score >= 69 ? '✅' : '❌');
+  return (score >= 3 ? '✅' : '❌');
 }
 
 function hoursToString(hoursDecimal) {
@@ -121,14 +122,15 @@ request(endpoint_today).then((json) => {
 // Get this week's productivity data
 request(endpoint_week).then((json) => {
   // Determine day of week for first entry of array
-  const days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday', 'Sunday'];
+  const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   const data_thisWeek = json.slice(0, 6); // Slice works differently in node vs. with BitBar. In BitBar, slice removes end index.
 
   data_thisWeek.forEach((data_day) => {
-    console.log(`${getTickOrCross(data_day.productivity_pulse)} ${getDayOfWeek(data_day.date)}: ${data_day.productivity_pulse} | href=${URL_DASH_DAY}${data_day.date} color=black`)
+    console.log(`${getTickOrCross(data_day.very_productive_hours)} ${getDayOfWeek(data_day.date)}: ${data_day.productivity_pulse} | href=${URL_DASH_DAY}${data_day.date} color=black`)
     console.log(`${hoursToString(data_day.very_productive_hours)} of ${hoursToString(data_day.total_hours)} (${data_day.very_productive_percentage}%)`)
     console.log(`---`)
   })
 }).catch((error) => {
   console.log(error)
 })
+


### PR DESCRIPTION
I just noticed the plugin has wrong info in plugin browsers, so updated the title and description accordingly:

![Screen-Shot-2022-05-10-16-45-28 96](https://user-images.githubusercontent.com/1534150/167644063-6cc3a8ef-eb9b-4bf3-b800-b5acc6eb857d.png)

This PR also fixes the color for the productivity percent. I also removed the emoji from menubar, it's a personal preference and you can leave it out from this, but FYI if you'd decide to use these.