### PR TITLE
Show indicators towards productive hours

### DIFF
--- a/rescuetime.5m.js
+++ b/rescuetime.5m.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env /usr/local/bin/node
 
-// <bitbar.title>People In Space</bitbar.title>
+// <bitbar.title>RescueTime Productivity Stats</bitbar.title>
 // <bitbar.version>v1.1</bitbar.version>
 // <bitbar.author>Mullwar</bitbar.author>
 // <bitbar.author.github>mullwar</bitbar.author.github>
-// <bitbar.desc>How many people are in Space right now?</bitbar.desc>
-// <bitbar.image>http://i.imgur.com/i9biB3R.png</bitbar.image>
+// <bitbar.desc>Show RescueTime Productivity in menubar</bitbar.desc>
+// <bitbar.image>https://i.imgur.com/7ShrdlB.png</bitbar.image>
 // <bitbar.dependencies>node</bitbar.dependencies>
 // <bitbar.abouturl>https://github.com/mullwar/bitbar-plugins</bitbar.abouturl>
 
@@ -16,7 +16,6 @@
 
 const https = require('https');
 const fs = require('fs');
-
 
 // Rescue time API key. Need to manually create an api.key file
 const PATH = `${process.env.HOME}/Library/RescueTime.com/api.key`;
@@ -57,7 +56,7 @@ function getDayOfWeek(date) {
 }
 
 function getColorFromScore(score) {
-  return (score >= 69 ? 'black' : 'red');
+  return (score >= 69 ? 'lightgreen' : 'red');
 }
 
 function getTickOrCross(score) {
@@ -109,7 +108,8 @@ request(endpoint_today).then((json) => {
     score = Math.floor((1*vpHours + .75*pHours + .5*nHours + .25*dHours + 0*vdHours)/today_hours*100);
   }
 
-  console.log(`🎯${score}  (${hoursToString(vpHours)} of ${hoursToString(today_hours)}) | color=${getColorFromScore(score)}`);
+  //console.log(`🎯${score}  (${hoursToString(vpHours)} of ${hoursToString(today_hours)}) | color=${getColorFromScore(score)}`);
+  console.log(`${score}%  | color=${getColorFromScore(score)}`);
   console.log(`---`);
   console.log(`${getTickOrCross(score)} Today: ${score} | href=https://www.rescuetime.com/dashboard color=black`);
   console.log(`${hoursToString(vpHours)} of ${hoursToString(today_hours)} (${Math.round(vpHours/today_hours*100)}%)`)

--- a/rescuetime.5m.js
+++ b/rescuetime.5m.js
@@ -27,7 +27,8 @@ const ENDPOINT_ACTIVITIES = 'https://www.rescuetime.com/anapi/data.json';
 const URL_DASH_DAY = 'https://www.rescuetime.com/dashboard/for/the/day/of/';
 
 let endpoint_week = `${ENDPOINT_FEED}?key=${API_KEY}`;
-let endpoint_today = `${ENDPOINT_ACTIVITIES}?key=${API_KEY}&perspective=interval&restrict_kind=productivity`;
+// Note &restrict_schedule_id=6839529, it restricts to 'work' schedule: https://www.rescuetime.com/dashboard?schedule_id=6839529
+let endpoint_today = `${ENDPOINT_ACTIVITIES}?key=${API_KEY}&perspective=interval&restrict_kind=productivity&restrict_schedule_id=6839529`;
 
 
 function request(endpoint) {
@@ -51,7 +52,7 @@ function request(endpoint) {
 
 function getDayOfWeek(date) {
   const dateObj = new Date(date);
-  const days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday', 'Sunday'];
+  const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   return days[dateObj.getDay()];
 }
 
@@ -60,7 +61,7 @@ function getColorFromScore(score) {
 }
 
 function getTickOrCross(score) {
-  return (score >= 69 ? '✅' : '❌');
+  return (score >= 3 ? '✅' : '❌');
 }
 
 function hoursToString(hoursDecimal) {
@@ -121,14 +122,15 @@ request(endpoint_today).then((json) => {
 // Get this week's productivity data
 request(endpoint_week).then((json) => {
   // Determine day of week for first entry of array
-  const days = ['Monday','Tuesday','Wednesday','Thursday','Friday','Saturday', 'Sunday'];
+  const days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
   const data_thisWeek = json.slice(0, 6); // Slice works differently in node vs. with BitBar. In BitBar, slice removes end index.
 
   data_thisWeek.forEach((data_day) => {
-    console.log(`${getTickOrCross(data_day.productivity_pulse)} ${getDayOfWeek(data_day.date)}: ${data_day.productivity_pulse} | href=${URL_DASH_DAY}${data_day.date} color=black`)
+    console.log(`${getTickOrCross(data_day.very_productive_hours)} ${getDayOfWeek(data_day.date)}: ${data_day.productivity_pulse} | href=${URL_DASH_DAY}${data_day.date} color=black`)
     console.log(`${hoursToString(data_day.very_productive_hours)} of ${hoursToString(data_day.total_hours)} (${data_day.very_productive_percentage}%)`)
     console.log(`---`)
   })
 }).catch((error) => {
   console.log(error)
 })
+


### PR DESCRIPTION
I noticed the daily summary never shows the the green checkmark because it counts it towards the whole day. For those who count it towards working day only, it shows the wrong information. I realized daily summary API doesn't support work schedule so I just decided to change this to use very productive hours, if they're more than 3 hours, check.

Feel free to not merge this PR if you don't like it. I just thought it would be a good idea.